### PR TITLE
Fix display issue for bash code by escaping special characters

### DIFF
--- a/docs/notebooks/inference/deepseekr1_sglang.ipynb
+++ b/docs/notebooks/inference/deepseekr1_sglang.ipynb
@@ -150,7 +150,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -173,17 +177,17 @@
     "    --security-opt seccomp=unconfined \\\n",
     "    --security-opt apparmor=unconfined \\\n",
     "    --env \"HIP_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES\" \\\n",
-    "    -p $INFERENCE_PORT:$INFERENCE_PORT \\\n",
+    "    -p \\$INFERENCE_PORT:\\$INFERENCE_PORT \\\n",
     "    -v ~/.cache/huggingface:/root/.cache/huggingface \\\n",
     "    --name sglang_server \\\n",
-    "    $SGLANG_DIMG \\\n",
+    "    \\$SGLANG_DIMG \\\n",
     "    python3 -m sglang.launch_server  \\\n",
-    "    --model $INFERENCE_MODEL \\\n",
-    "    --port $INFERENCE_PORT \\\n",
+    "    --model \\$INFERENCE_MODEL \\\n",
+    "    --port \\$INFERENCE_PORT \\\n",
     "    --trust-remote-code \\\n",
     "    --disable-radix-cache \\\n",
     "    --host 0.0.0.0 \\\n",
-    "    --api-key $API_KEY "
+    "    --api-key \\$API_KEY "
    ]
   },
   {


### PR DESCRIPTION
Deal with display and formatting issues for a bash code block by escaping "$" characters with a backlash (converted to \\ in the source)