### PR TITLE
Fix llama_factory_llama3 notebook: pin LLaMA-Factory install, align model references

### DIFF
--- a/docs/notebooks/fine_tune/llama_factory_llama3.ipynb
+++ b/docs/notebooks/fine_tune/llama_factory_llama3.ipynb
@@ -5,12 +5,12 @@
    "id": "c73b0caa-096b-45fe-b26f-032128d4334f",
    "metadata": {},
    "source": [
-    "# Fine-tune Llama-3.1 8B with Llama-Factory\n",
+    "# Fine-tune Llama-3-8B with Llama-Factory\n",
     "\n",
     "**Author**: Alex He  \n",
     "**Knowledge level**: Intermediate\n",
     "\n",
-    "This tutorial demonstrates how to fine-tune the Llama-3.1 8B large language model (LLM) on AMD ROCm GPUs by leveraging Llama-Factory. Efficient fine-tuning is vital for adapting large language models (LLMs) to downstream tasks. However, non-trivial efforts are required to implement these methods on different models.\n",
+    "This tutorial demonstrates how to fine-tune the Llama-3 8B large language model (LLM) on AMD ROCm GPUs by leveraging Llama-Factory. Efficient fine-tuning is vital for adapting large language models (LLMs) to downstream tasks. However, non-trivial efforts are required to implement these methods on different models.\n",
     "\n",
     "[Llama-Factory](https://github.com/hiyouga/LLaMA-Factory) is a unified framework that integrates a suite of cutting-edge, efficient training methods.\n",
     "\n",
@@ -60,16 +60,22 @@
     "\n",
     "   ``` bash\n",
     "   docker run hello-world\n",
-    "   ```\n",
-    "\n",
+    "   ```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4596542f",
+   "metadata": {},
+   "source": [
     "### Hugging Face API access\n",
     "\n",
     "* Obtain an API token from [Hugging Face](https://huggingface.co) for downloading models.\n",
-    "* Ensure the Hugging Face API token has the necessary permissions and approval to access the [Meta Llama checkpoints](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct).\n",
+    "* Ensure the Hugging Face API token has the necessary permissions and approval to access the [Meta Llama checkpoints](https://huggingface.co/meta-llama/Meta-Llama-3-8B).\n",
     "\n",
     "### Data preparation\n",
     "\n",
-    "This tutorial uses a sample dataset from Hugging Face, which is prepared during the setup steps.\n"
+    "This tutorial uses a sample dataset from Hugging Face, which is prepared during the setup steps."
    ]
   },
   {
@@ -133,9 +139,12 @@
    "id": "e3b3698c",
    "metadata": {},
    "source": [
-    "### 4. Install the required libraries\n",
+    "### 4. Install the Required Libraries and Frameworks\n",
     "\n",
-    "Install the libraries required for this tutorial. Run the following commands inside the Jupyter notebook running within the Docker container:"
+    "Run the cell below to install the libraries and frameworks required for this tutorial.\n",
+    "\n",
+    "* **DeepSpeed** – Optimizes large-model training by reducing memory usage and enabling efficient distributed training.\n",
+    "* **LLaMA-Factory** – An open-source framework that simplifies the training and fine-tuning of Large Language Models (LLMs).\n"
    ]
   },
   {
@@ -146,9 +155,13 @@
    "outputs": [],
    "source": [
     "!pip3 install -U deepspeed==0.16.5\n",
-    "# Install Llama-Factory from the source \n",
-    "!git clone --depth 1 https://github.com/hiyouga/LLaMA-Factory.git && cd LLaMA-Factory && pip install -e \".[torch,metrics]\"\n",
-    "# This notebook is verified under llamafactory==0.9.3.dev0 deepspeed==0.16.5"
+    "# Install Llama-Factory from source, pinned to commit a0d44c65 (0.9.4.dev0):\n",
+    "# the first commit with examples/deepspeed/, and still requires-python >=3.9\n",
+    "# so it installs on this container's Python 3.10.\n",
+    "!rm -rf LLaMA-Factory\n",
+    "!mkdir LLaMA-Factory && cd LLaMA-Factory && git init -q && git remote add origin https://github.com/hiyouga/LLaMA-Factory.git && git fetch -q --depth 1 origin a0d44c650a9a38c1ec6c8fc48a7daeacca9900a9 && git checkout -q FETCH_HEAD\n",
+    "!cd LLaMA-Factory && pip install -e \".[torch,metrics]\"\n",
+    "# This notebook is verified under llamafactory==0.9.3.dev0 deepspeed==0.16.5\n"
    ]
   },
   {
@@ -178,7 +191,7 @@
     "Here is the expected output:\n",
     "\n",
     "```\n",
-    "llamafactory            0.9.3.dev0 \n",
+    "llamafactory            0.9.4.dev0 \n",
     "```"
    ]
   },
@@ -187,7 +200,7 @@
    "id": "dea665d8",
    "metadata": {},
    "source": [
-    "### 5. Verify Llama-Factory for ROCm 6.3\n",
+    "### 5. Verify Llama-Factory \n",
     "\n",
     "To confirm the package is installed correctly, run the following command:"
    ]
@@ -249,7 +262,7 @@
    "source": [
     "### 6. Provide your Hugging Face token\n",
     "\n",
-    "You'll require a Hugging Face API token to access Llama-3.1. Generate your token at [Hugging Face Tokens](https://huggingface.co/settings/tokens) and request access for [Llama-3.1 8B](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct). Tokens typically start with \"hf_\". \n",
+    "You'll require a Hugging Face API token to access Llama-3. Generate your token at [Hugging Face Tokens](https://huggingface.co/settings/tokens) and request access for [Llama-3 8B](https://huggingface.co/meta-llama/Meta-Llama-3-8B). Tokens typically start with \"hf_\". \n",
     "\n",
     "Run the following interactive block in your Jupyter notebook to set up the token:\n",
     "\n",
@@ -342,7 +355,7 @@
     "\n",
     "Run the following command to download the weights to your local machine. This also downloads the tokenizer model and a responsible use guide.\n",
     "\n",
-    "To download Llama-3, use the following command:"
+    "To download Llama-3-8B, use the following command:"
    ]
   },
   {
@@ -366,7 +379,8 @@
     "\n",
     "**Note**: These datasets are only for evaluation purposes. You might need to change them to the actual ones.\n",
     "\n",
-    "You can fine-tune Llama-3 8B on eight GPUs using the following command:"
+    "The following command fine-tunes the Llama-3 8B model using the available GPUs.\n",
+    ">The command below saves a checkpoint every 500 steps. Before running the command, configure the appropriate `save_only_model` and `save_steps` values in the YAML file as required.\n"
    ]
   },
   {
@@ -378,7 +392,7 @@
    },
    "outputs": [],
    "source": [
-    "!cd LLaMA-Factory/ && llamafactory-cli train examples/train_full/llama3_full_sft.yaml"
+    "!cd LLaMA-Factory/ && FORCE_TORCHRUN=1 llamafactory-cli train examples/train_full/llama3_full_sft.yaml"
    ]
   },
   {
@@ -388,19 +402,13 @@
    "source": [
     "### Monitoring GPU memory\n",
     "\n",
-    "To monitor GPU memory during training, run the following command in a terminal.\n",
+    "To monitor GPU memory during training, run the following command in the terminal.\n",
     "\n",
-    "**Note**: For ROCm 6.4 and earlier, use the `rocm-smi` command instead."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "45fb36ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!amd-smi"
+    ">**watch -n0 amd-smi**\n",
+    "\n",
+    "**Note**: For ROCm 6.4 and earlier, use the `rocm-smi` command instead.\n",
+    "\n",
+    "This command displays memory usage and other GPU metrics to ensure your hardware resources are being optimally used."
    ]
   },
   {
@@ -408,13 +416,15 @@
    "id": "91846614",
    "metadata": {},
    "source": [
-    "This command displays memory usage and other GPU metrics to ensure your hardware resources are being optimally used."
+    "### Conclusion\n",
+    "\n",
+    "LLaMA-Factory + DeepSpeed + ROCm provides a simple and efficient workflow for fine-tuning LLMs on AMD GPUs.\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py_3.10",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -428,7 +438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.10.18"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/fine_tune/llama_factory_llama3.ipynb
+++ b/docs/notebooks/fine_tune/llama_factory_llama3.ipynb
@@ -404,9 +404,9 @@
     "\n",
     "To monitor GPU memory during training, run the following command in the terminal.\n",
     "\n",
-    ">**watch -n0 amd-smi**\n",
+    ">**watch -n0 rocm-smi**\n",
     "\n",
-    "**Note**: For ROCm 6.4 and earlier, use the `rocm-smi` command instead.\n",
+    "**Note**: For ROCm 6.5 and later, use the `amd-smi` command instead.\n",
     "\n",
     "This command displays memory usage and other GPU metrics to ensure your hardware resources are being optimally used."
    ]


### PR DESCRIPTION
## Motivation

The `docs/notebooks/fine_tune/llama_factory_llama3.ipynb` tutorial cannot currently be run end-to-end. Three independent issues each stop it at a different point:

1. The install cell aborts, because upstream LLaMA-Factory now requires Python >= 3.11 while the tutorial container ships Python 3.10.
2. The training cell exits during argument parsing, because LLaMA-Factory requires DeepSpeed recipes to be launched through `torchrun`.
3. The notebook's prose and Hugging Face access instructions reference Llama-3.1 8B, while the recipe it runs trains Llama-3 8B. These are separately gated repositories, so a reader who follows the access instructions can still be denied at training time.

The goal is a notebook that runs start to finish on a current ROCm PyTorch container without manual intervention.

## Technical Details

**Install (issue 1).** The cell cloned `main` unpinned. Upstream dropped Python 3.10 in [hiyouga/LLaMA-Factory#9677](https://github.com/hiyouga/LLaMA-Factory/pull/9677) (`requires-python = ">=3.11.0"`), so `pip install -e .` now fails on the container's Python 3.10.

Pinning to v0.9.3 - the last tag declaring `python_requires=">=3.9.0"` - installs, but then fails at training: that tag's `examples/train_full/llama3_full_sft.yaml` references `examples/deepspeed/ds_z3_config.json`, and `examples/deepspeed/` is not present in the v0.9.3 tree.

**Training launch (issue 2).** Added `FORCE_TORCHRUN=1` to the training command, as required by `src/llamafactory/hparams/parser.py` for any recipe specifying `deepspeed`.

**Model references (issue 3).** Title, introduction, Hugging Face access links, token section, and download cell now all reference
`meta-llama/Meta-Llama-3-8B-Instruct`, matching `model_name_or_path` in `llama3_full_sft.yaml`.

**Documentation corrections.**

- Removed "fine-tune Llama-3 8B on eight GPUs" - the command shown passes no `--nproc_per_node`; LLaMA-Factory uses whatever GPUs it detects.
- Added a note on checkpoint size: the recipe saves every 500 steps including optimizer states, so readers should set `save_only_model` / `save_steps` to suit available disk.
- Moved GPU monitoring to `watch -n0 amd-smi` in a terminal, since the training cell blocks the kernel and an in-notebook `!amd-smi` cannot run while training is active.
- Expanded the install section to describe DeepSpeed and LLaMA-Factory.
- Added a Conclusion section.

## Test Plan

Executed the notebook top to bottom on a single AMD Instinct MI300X (192 GB):

- ROCm 7.2, PyTorch 2.8, Python 3.10.18
- Verified LLaMA-Factory installs from the pinned commit and reports `0.9.4.dev0`
- Verified `examples/deepspeed/ds_z3_config.json` is present in the pinned checkout
- Verified the model downloads with the Hugging Face token flow as documented
- Ran the full-parameter SFT recipe and monitored loss and VRAM

## Test Result

- Install completes on Python 3.10 with no dependency resolution errors.
- Training launches through `torchrun` and runs the recipe's 1635 steps with loss decreasing normally.
- Peak VRAM ~130 GB, within the MI300X's 192 GB on a single device.