### PR TITLE
Fix ocr_vllm notebook: Docker workdir, missing huggingface-hub dep, a…

### DIFF
--- a/docs/notebooks/inference/ocr_vllm.ipynb
+++ b/docs/notebooks/inference/ocr_vllm.ipynb
@@ -76,7 +76,7 @@
     "### Hugging Face API access\n",
     "\n",
     "* Obtain an API token from [Hugging Face](https://huggingface.co) for downloading models.\n",
-    "* Ensure the Hugging Face API token has the necessary permissions and approval to access the [Meta Llama checkpoints](https://huggingface.co/meta-llama/Llama-3.1-8B)."
+    "* Ensure the Hugging Face API token has the necessary permissions and approval to access the [Meta Llama checkpoints](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct)."
    ]
   },
   {
@@ -101,7 +101,7 @@
     "  --hostname=ROCm-FT \\\n",
     "  --env HUGGINGFACE_HUB_CACHE=/workspace \\\n",
     "  -v $(pwd):/workspace \\\n",
-    "  -w /workspace/notebooks \\\n",
+    "  -w /workspace \\\n",
     "  --entrypoint /bin/bash \\\n",
     "  rocm/vllm-dev:main\n",
     "```\n",
@@ -141,7 +141,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install gradio requests"
+    "!pip install \"huggingface-hub>=0.26.0,<1.0\" gradio requests"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "source": [
     "### Provide your Hugging Face token\n",
     "\n",
-    "You'll require a Hugging Face API token to access Llama-3.1-8B. Generate your token at [Hugging Face Tokens](https://huggingface.co/settings/tokens) and request access for [Llama-3.2-11B-Vision-Instruct](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct). Tokens typically start with \"hf_\".\n",
+    "You'll require a Hugging Face API token to access Llama-3.2-11B-Vision-Instruct. Generate your token at [Hugging Face Tokens](https://huggingface.co/settings/tokens) and request access for [Llama-3.2-11B-Vision-Instruct](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct). Tokens typically start with \"hf_\".\n",
     "\n",
     "Run the following interactive block in your Jupyter notebook to set up the token:"
    ]


### PR DESCRIPTION
## Motivation

The `inference/ocr_vllm` notebook had a few issues that could trip up users following it end-to-end:

- The Docker command set the working directory to `/workspace/notebooks`, an empty path, so JupyterLab opened an empty folder instead of the mounted directory containing the notebook.
- The dependency install cell was missing `huggingface-hub`, which is required for the Hugging Face token login used later in the notebook.
- The prerequisites and token sections referenced `Llama-3.1-8B`, but the notebook actually loads `Llama-3.2-11B-Vision-Instruct` (a vision model). `Llama-3.1-8B` is text-only and can't perform OCR, so the references were both incorrect and misleading.

## Technical Details

- Changed the Docker run flag `-w /workspace/notebooks` to `-w /workspace` so Jupyter opens the mounted invocation directory.
- Added `"huggingface-hub>=0.26.0,<1.0"` to the `pip install` cell alongside `gradio` and `requests`.
- Updated the model references from `Llama-3.1-8B` to `Llama-3.2-11B-Vision-Instruct` in:
    1. the Prerequisites section (Hugging Face checkpoint link)
    2. the "Provide your Hugging Face token" section

**No code logic or the OCR inference flow was changed.**

## Test Plan

- Ran the Docker command and confirmed JupyterLab opens the mounted working directory (not an empty `notebooks` folder).
- Executed the notebook top to bottom in the ROCm vLLM container: dependency install, Hugging Face login/token validation, model load, and OCR inference on the sample image.
- Verified the Hugging Face checkpoint links resolve to `Llama-3.2-11B-Vision-Instruct`.

## Test Result

- JupyterLab opens the correct mounted directory.
- Dependencies install cleanly and `notebook_login()` / token validation succeed.
- `Llama-3.2-11B-Vision-Instruct` loads and produces the expected OCR output on the sample image.
- The Gradio interface launches, and both an uploaded image and a webcam capture are analyzed correctly.