### PR TITLE
docs(AI Tutorials): Fix deadlinks in v14 docs

### DIFF
--- a/docs/notebooks/pretrain/se3transform_intro.ipynb
+++ b/docs/notebooks/pretrain/se3transform_intro.ipynb
@@ -43,7 +43,7 @@
         "\n",
         "* **GPU**: AMD Instinct™ MI300X or MI250X GPUs.\n",
         "\n",
-        "**Note**: This tutorial has been tested and validated on AMD Instinct MI300X GPUs. For the official list of supported GPUs, see the [DGL Compatibility Documentation](https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/dgl-compatibility.html). For performance metrics on AMD Instinct GPUs, see the [SE(3)-Transformer performance report blog](https://rocm.blogs.amd.com/artificial-intelligence/dgl-in-depth/README.html).\n",
+        "**Note**: This tutorial has been tested and validated on AMD Instinct MI300X GPUs. For the official list of supported GPUs, see the [DGL Compatibility Documentation](https://rocm.docs.amd.com/en/docs-7.2.4/compatibility/ml-compatibility/dgl-compatibility.html). For performance metrics on AMD Instinct GPUs, see the [SE(3)-Transformer performance report blog](https://rocm.blogs.amd.com/artificial-intelligence/dgl-in-depth/README.html).\n",
         "\n",
         "### Software requirements\n",
         "\n",

--- a/docs/notebooks/pretrain/training_with_primus.ipynb
+++ b/docs/notebooks/pretrain/training_with_primus.ipynb
@@ -279,7 +279,7 @@
    "id": "22625c2e-fbc3-485b-9d83-9559c19f5de5",
    "metadata": {},
    "source": [
-    "After setup is complete, run the appropriate training commands. The following run commands are tailored to Qwen2.5-7B. See [Supported models](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/primus-megatron.html?model=primus_pyt_megatron_lm_train_qwen2.5-7b) to switch to another available model."
+    "After setup is complete, run the appropriate training commands. The following run commands are tailored to Qwen2.5-7B. See [Supported models](•	https://rocm.docs.amd.com/projects/primus/en/latest/06-developer-guide/model-support-matrix.html) to switch to another available model."
    ]
   },
   {
@@ -426,7 +426,7 @@
    "source": [
     "## Further reading\n",
     "- For an introduction to Primus, see [Primus: A Lightweight, Unified Training Framework for Large Models on AMD GPUs](https://rocm.blogs.amd.com/software-tools-optimization/primus/README.html).\n",
-    "- To learn how to set up and run training with Primus in combination with PyTorch, see [Training a model with Primus and Pytorch](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/primus-pytorch.html?model=primus_pyt_train_llama-3.1-8b#).\n",
+    "- To learn how to set up and run training with Primus in combination with PyTorch, see [Training a model with Primus and Pytorch TorchTitan](https://rocm.docs.amd.com/projects/primus/en/latest/02-user-guide/torchtitan-training.html).\n",
     "- To learn more about system settings and management practices to configure your system for AMD Instinct MI300X series GPUs, see [AMD Instinct MI300X system optimization](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/system-optimization/mi300x.html).\n",
     "- For a list of other ready-made Docker images for AI with ROCm, see [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html#f-amd_hub_category=AI%20%26%20ML%20Models)."
    ]

--- a/docs/notebooks/pretrain/training_with_primus.ipynb
+++ b/docs/notebooks/pretrain/training_with_primus.ipynb
@@ -279,7 +279,7 @@
    "id": "22625c2e-fbc3-485b-9d83-9559c19f5de5",
    "metadata": {},
    "source": [
-    "After setup is complete, run the appropriate training commands. The following run commands are tailored to Qwen2.5-7B. See [Supported models](•	https://rocm.docs.amd.com/projects/primus/en/latest/06-developer-guide/model-support-matrix.html) to switch to another available model."
+    "After setup is complete, run the appropriate training commands. The following run commands are tailored to Qwen2.5-7B. See [Supported models](https://rocm.docs.amd.com/projects/primus/en/latest/06-developer-guide/model-support-matrix.html) to switch to another available model."
    ]
   },
   {

--- a/docs/notebooks/pretrain/training_with_primus.ipynb
+++ b/docs/notebooks/pretrain/training_with_primus.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "This tutorial demonstrates how to pretrain the [Qwen2.5-7B](https://huggingface.co/Qwen/Qwen2.5-7B) large language model (LLM) using ROCm on AMD GPUs by leveraging Primus. Primus is a unified and flexible training framework for AMD Instinct™ GPUs that's designed to support multiple training engine backends, including Megatron, to deliver scalable, high-performance model training. Performance acceleration is powered by [Primus-Turbo](https://github.com/AMD-AGI/Primus-Turbo) and the ROCm libraries.\n",
     "\n",
-    "Primus with Megatron is designed to replace the [ROCm Megatron-LM training](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/megatron-lm.html) workflow. To learn how to migrate workloads from Megatron-LM to Primus with Megatron, see [Migrating workloads to Primus (Megatron backend) from Megatron-LM](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-primus-migration-guide.html).\n",
+    "Primus with Megatron is designed to replace the [ROCm Megatron-LM training](https://rocm.docs.amd.com/en/docs-7.2.4/how-to/rocm-for-ai/training/benchmark-docker/megatron-lm.html) workflow. To learn how to migrate workloads from Megatron-LM to Primus with Megatron, see [Migrating workloads to Primus (Megatron backend) from Megatron-LM](https://rocm.docs.amd.com/en/docs-7.2.4/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-primus-migration-guide.html).\n",
     "\n",
     "By following this tutorial, you'll learn how to set up and run training with Primus, take advantage of its performance optimizations, and gain practical experience in using Primus to streamline model training workflows."
    ]
@@ -222,7 +222,7 @@
    "metadata": {},
    "source": [
     "## Run training\n",
-    "Use the following example commands to set up the environment, configure [key options](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.8.html?model=primus_pyt_megatron_lm_train_qwen2.5-7b), and run training on AMD Instinct GPUs using Primus with the Megatron backend."
+    "Use the following example commands to set up the environment, configure [key options](https://rocm.docs.amd.com/en/docs-7.2.4/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.8.html?model=primus_pyt_megatron_lm_train_qwen2.5-7b), and run training on AMD Instinct GPUs using Primus with the Megatron backend."
    ]
   },
   {

--- a/docs/notebooks/pretrain/triton_inference_server_benchmark.ipynb
+++ b/docs/notebooks/pretrain/triton_inference_server_benchmark.ipynb
@@ -871,7 +871,7 @@
     "  - [MIGraphX documentation](https://rocm.docs.amd.com/projects/AMDMIGraphX/en/latest/)     \n",
     "  - [ROCm ONNX Runtime + MIGraphX EP](https://rocm.docs.amd.com/projects/radeon/en/latest/docs/rocm_ai/onnxruntime.html)                                      \n",
     "  - [Triton Inference Server (ROCm fork)](https://github.com/ROCm/triton-inference-server-server/tree/rocm7.2_r25.12)                                         \n",
-    "  - [Triton Inference Server `perf_analyzer` CLI reference](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/client/src/c%2B%2B/perf_analyzer/docs/cli.html)\n",
+    "  - [Triton Inference Server `perf_analyzer` CLI reference](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/perf_analyzer/docs/cli.html)\n",
     "  - [BARS CTR leaderboard](https://openbenchmark.github.io/BARS/CTR/leaderboard/criteo_x4.html)                                                               \n",
     "  - [FinalNet paper (SIGIR 2023)](https://arxiv.org/abs/2301.01624)\n",
     "  - [Criteo\\_x4 dataset](https://huggingface.co/datasets/reczoo/Criteo_x4)    \n"


### PR DESCRIPTION
## Motivation

A few deadlinks in the v14 documentation were fixed in v.15, but never in v.14. This PR fixes them.

## Technical Details

Pointing those links back to the proper versions of the target references.

## Test Plan

Check built docs.

## Test Result

Built docs look OK.

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
