### PR TITLE
docs(AI Tutorials): Fix deadlinks in v15 docs

### DIFF
--- a/docs/notebooks/pretrain/training_with_primus.ipynb
+++ b/docs/notebooks/pretrain/training_with_primus.ipynb
@@ -279,7 +279,7 @@
    "id": "22625c2e-fbc3-485b-9d83-9559c19f5de5",
    "metadata": {},
    "source": [
-    "After setup is complete, run the appropriate training commands. The following run commands are tailored to Qwen2.5-7B. See [Supported models](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/primus-megatron.html?model=primus_pyt_megatron_lm_train_qwen2.5-7b) to switch to another available model."
+    "After setup is complete, run the appropriate training commands. The following run commands are tailored to Qwen2.5-7B. See [Supported models](https://rocm.docs.amd.com/projects/primus/en/latest/06-developer-guide/model-support-matrix.html) to switch to another available model."
    ]
   },
   {
@@ -426,7 +426,7 @@
    "source": [
     "## Further reading\n",
     "- For an introduction to Primus, see [Primus: A Lightweight, Unified Training Framework for Large Models on AMD GPUs](https://rocm.blogs.amd.com/software-tools-optimization/primus/README.html).\n",
-    "- To learn how to set up and run training with Primus in combination with PyTorch, see [Training a model with Primus and Pytorch](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/primus-pytorch.html?model=primus_pyt_train_llama-3.1-8b#).\n",
+    "- To learn how to set up and run training with Primus in combination with PyTorch, see [Training a model with Primus and Pytorch TorchTitan](https://rocm.docs.amd.com/projects/primus/en/latest/02-user-guide/torchtitan-training.html).\n",
     "- To learn more about system settings and management practices to configure your system for AMD Instinct MI300X series GPUs, see [AMD Instinct MI300X system optimization](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/system-optimization/mi300x.html).\n",
     "- For a list of other ready-made Docker images for AI with ROCm, see [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html#f-amd_hub_category=AI%20%26%20ML%20Models)."
    ]


### PR DESCRIPTION
Jira #:  AIROCDOC-20

## Motivation

Fix two links that point to the old Primus documentation.

## Technical Details

Point to the new Primus documentation instead.

## Test Plan

Check the doc built

## Test Result

Doc built is OK.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
